### PR TITLE
add lb option to show-stats

### DIFF
--- a/.github/workflows/nvidia_workflow.yml
+++ b/.github/workflows/nvidia_workflow.yml
@@ -28,6 +28,8 @@ jobs:
     - name: Create input files
       shell: bash
       run: |
+        # install jq
+        apt update && apt install -y jq
         # Extract the payload content without printing it
         PAYLOAD=$(jq -r '.inputs.payload' $GITHUB_EVENT_PATH)
         

--- a/src/discord-cluster-manager/cogs/admin_cog.py
+++ b/src/discord-cluster-manager/cogs/admin_cog.py
@@ -763,7 +763,9 @@ class AdminCog(commands.Cog):
 
     @with_error_handling
     @discord.app_commands.describe(last_day_only="Only show stats for the last day")
-    async def show_bot_stats(self, interaction: discord.Interaction, last_day_only: bool):
+    @discord.app_commands.describe(leaderboard_name="Name of the leaderboard")
+    @app_commands.autocomplete(leaderboard_name=leaderboard_name_autocomplete)
+    async def show_bot_stats(self, interaction: discord.Interaction, last_day_only: bool, leaderboard_name: Optional[str] = None):
         is_admin = await self.admin_check(interaction)
         if not is_admin:
             await send_discord_message(
@@ -774,7 +776,7 @@ class AdminCog(commands.Cog):
             return
 
         with self.bot.leaderboard_db as db:
-            stats = db.generate_stats(last_day_only)
+            stats = db.generate_stats(last_day_only, leaderboard_name)
             msg = """```"""
             for k, v in stats.items():
                 msg += f"\n{k} = {v}"


### PR DESCRIPTION
This is a pretty simple pr that adds an lb option to show-stats. Right now it just shows average runtime as an extra stat, but I'll add a baseline time in a future pr (this is involved enough I wanted to  break it out)

Here's a pic of stats. First one is the default and the second is for a single leaderboard.

<img width="876" alt="Screenshot 2025-05-23 at 12 30 20 PM" src="https://github.com/user-attachments/assets/1cf6a308-3798-4f96-b872-ad68f03bb044" />


