### PR TITLE
Milestone V2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,9 @@ on:
       - main
       - dev
   pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
   unit-tests:

--- a/examples/matmul_py/task.yml
+++ b/examples/matmul_py/task.yml
@@ -9,9 +9,15 @@ files:
 
 milestones:
   - {
-      "name": "pytorch reference",
-      "source": "submission.py",
-      "description": "PyTorch reference implementation as a performance baseline for matmul"
+      name: "pytorch",
+      source: "submission.py",
+      description: "PyTorch reference implementation as a performance baseline for matmul"
+    }
+  - {
+      name: "triton",
+      source: "triton_ref.py",
+      description: "Triton reference implementation as a performance baseline for matmul",
+      exclude_gpus: ['T4']
     }
 
 lang: "py"

--- a/examples/matmul_py/task.yml
+++ b/examples/matmul_py/task.yml
@@ -7,6 +7,13 @@ files:
   - {"name": "reference.py", "source": "reference.py"}
   - {"name": "eval.py", "source": "../eval.py"}
 
+milestones:
+  - {
+      "name": "pytorch reference",
+      "source": "submission.py",
+      "description": "PyTorch reference implementation as a performance baseline for matmul"
+    }
+
 lang: "py"
 
 description: |

--- a/examples/matmul_py/triton_ref.py
+++ b/examples/matmul_py/triton_ref.py
@@ -1,0 +1,127 @@
+#!POPCORN leaderboard matmul_py
+import triton
+import triton.language as tl
+import torch
+from task import input_t, output_t
+
+
+@triton.jit
+def matmul_kernel(
+    # Pointers to matrices
+    a_ptr, b_ptr, c_ptr,
+    # Matrix dimensions
+    M, N, K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 cache hit rates.
+    # See above `L2 Cache Optimizations` section for details.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    # See above `Pointer Arithmetic` section for details
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher precision.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        # Load the next block of A and B, generate a mask by checking the K dimension.
+        # If it is out of bounds, set it to 0.
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        # We accumulate along the K dimension.
+        accumulator += tl.dot(a, b)
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+    # You can fuse arbitrary activation functions here
+    # while the accumulator is still in FP32!
+    c = accumulator.to(tl.float16)
+
+    # -----------------------------------------------------------
+    # Write back the block of the output matrix C with masks.
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def triton_matmul(a, b):
+    # Check constraints.
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+    assert b.is_contiguous(), "Matrix B must be contiguous"
+    M, K = a.shape
+    K, N = b.shape
+    # Allocate output.
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    # 1D launch kernel where each block gets its own program.
+    grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
+    matmul_kernel[grid](
+        a, b, c,
+        M, N, K,
+        a.stride(0), a.stride(1),
+        b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+        BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32,
+        GROUP_SIZE_M=8,
+    )
+    return c
+
+
+def custom_kernel(data: input_t) -> output_t:
+    a, b = data
+    # Convert to torch tensors if they aren't already
+    if not isinstance(a, torch.Tensor):
+        a = torch.tensor(a, dtype=torch.float16).cuda()
+    if not isinstance(b, torch.Tensor):
+        b = torch.tensor(b, dtype=torch.float16).cuda()
+    
+    # Ensure tensors are on GPU and contiguous
+    if not a.is_cuda:
+        a = a.cuda()
+    if not b.is_cuda:
+        b = b.cuda()
+    
+    a = a.contiguous()
+    b = b.contiguous()
+    
+    # Use our custom Triton matmul
+    result = triton_matmul(a, b)
+    
+    # Convert back to the expected output format
+    return result

--- a/src/kernelbot/cogs/admin_cog.py
+++ b/src/kernelbot/cogs/admin_cog.py
@@ -381,6 +381,7 @@ class AdminCog(commands.Cog):
                         milestone.name,
                         milestone.code,
                         description=milestone.description,
+                        exclude_gpus=milestone.exclude_gpus,
                     )
             except KernelBotError as e:
                 await send_discord_message(
@@ -457,10 +458,19 @@ class AdminCog(commands.Cog):
                 if gpu in [r["runner"] for r in existing_runs]:
                     await send_discord_message(
                         interaction,
-                        f"Skipping {gpu}; milestone run already exists.",
+                        f"Skipping {gpu} for {milestone['name']}; milestone run already exists.",
                         ephemeral=True,
                     )
                     continue
+
+                if gpu in milestone["exclude_gpus"]:
+                    await send_discord_message(
+                        interaction,
+                        f"Skipping {gpu} for {milestone['name']}; is excluded.",
+                        ephemeral=True,
+                    )
+                    continue
+
                 submit_tasks.append(
                     submit_milestone(
                         milestone,

--- a/src/kernelbot/cogs/admin_cog.py
+++ b/src/kernelbot/cogs/admin_cog.py
@@ -434,6 +434,13 @@ class AdminCog(commands.Cog):
 
             with backend.db as db:
                 for key, value in result.runs.items():
+                    # Only store LB runs in the database;
+                    # we still want to run test/benchmark to validate
+                    # that the code actually passes, but for all other
+                    # purposes we only need the leaderboard run
+                    if key != SubmissionMode.LEADERBOARD.value:
+                        continue
+
                     db.create_submission_run(
                         milestone=milestone["id"],
                         start=value.start,

--- a/src/kernelbot/cogs/leaderboard_cog.py
+++ b/src/kernelbot/cogs/leaderboard_cog.py
@@ -1,4 +1,3 @@
-import math
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import TYPE_CHECKING, List, Optional
@@ -23,9 +22,8 @@ from libkernelbot.leaderboard_db import (
     RunItem,
     SubmissionItem,
 )
-from libkernelbot.report import make_benchmark_log
 from libkernelbot.submission import SubmissionRequest, prepare_submission
-from libkernelbot.utils import format_time, run_item_to_run_result, setup_logging
+from libkernelbot.utils import format_time, setup_logging
 
 if TYPE_CHECKING:
     from kernelbot.main import ClusterBot
@@ -611,53 +609,10 @@ class LeaderboardCog(commands.Cog):
     ):
         await interaction.response.defer(ephemeral=True)
 
-        message = f"# Milestones for `{leaderboard_name}`\n"
-
         try:
-            with self.bot.leaderboard_db as db:
-                lb = db.get_leaderboard(leaderboard_name)
-                milestones = db.get_leaderboard_milestones(leaderboard_id=lb["id"])
-
-            if len(milestones) == 0:
-                await send_discord_message(
-                    interaction,
-                    f"Leaderboard `{leaderboard_name}` does not provide any milestones",
-                    ephemeral=True,
-                )
-                return
-
-            for milestone in milestones:
-                message += f"## {milestone['name']}\n"
-                message += milestone["description"] + "\n"
-                with self.bot.leaderboard_db as db:
-                    runs = db.get_runs_generic(milestone_id=milestone["id"])
-
-                runs = [r for r in runs if r["mode"] == SubmissionMode.LEADERBOARD.value]
-
-                if len(runs) == 0:
-                    message += "⚠️ No runs available. Maybe they haven't been triggered yet?\n"
-
-                if gpu is not None:
-                    runs = [r for r in runs if r["runner"] == gpu]
-                if len(runs) == 0:
-                    message += f"⚠️ No runs available for GPU {gpu}\n"
-
-                max_len = 0
-                min_val = float("inf")
-                for run in runs:
-                    max_len = max(max_len, len(run["runner"]))
-                    min_val = min(min_val, run["score"])
-
-                digits = max(0, 1 - math.floor(math.log10(min_val)))
-
-                message += "```\n"
-                for run in runs:
-                    message += f" {run['runner']:<{max_len}}: {run['score']:.{digits}f}\n"
-                message += "```\n\n"
-
             await send_discord_message(
                 interaction,
-                message,
+                self.bot.backend.get_milestone_overview(leaderboard_name, gpu),
                 ephemeral=True,
             )
 
@@ -685,41 +640,7 @@ class LeaderboardCog(commands.Cog):
         gpu: Optional[str] = None,
     ):
         await interaction.response.defer(ephemeral=True)
-        with self.bot.leaderboard_db as db:
-            lb = db.get_leaderboard(leaderboard_name)
-            milestones = db.get_leaderboard_milestones(leaderboard_id=lb["id"])
-
-        selected = None
-        for milestone in milestones:
-            if milestone["name"].lower() == milestone_name.lower():
-                selected = milestone
-                break
-
-        if selected is None:
-            await send_discord_message(
-                interaction,
-                f"Could not find milestone `{milestone_name}` for leaderboard `{leaderboard_name}`",
-                ephemeral=True,
-            )
-            return
-
-        with self.bot.leaderboard_db as db:
-            runs = db.get_runs_generic(milestone_id=selected["id"])
-
-        runs = [r for r in runs if r["mode"] == SubmissionMode.LEADERBOARD.value]
-
-        if len(runs) == 0:
-            await send_discord_message(
-                interaction,
-                f"⚠️ No runs available for milestone `{milestone_name}`."
-                "Maybe they haven't been triggered yet?",
-                ephemeral=True,
-            )
-            return
-
-        for run in runs:
-            log = make_benchmark_log(run_item_to_run_result(run))
-            message = f"{milestone_name} on {run['runner']}\n```{log}```\n"
+        for message in self.bot.backend.get_milestone_result(leaderboard_name, milestone_name, gpu):
             await send_discord_message(
                 interaction,
                 message,

--- a/src/libkernelbot/db_types.py
+++ b/src/libkernelbot/db_types.py
@@ -56,4 +56,12 @@ class SubmissionItem(TypedDict):
     runs: List[RunItem]
 
 
-__all__ = [LeaderboardItem, LeaderboardRankedEntry, RunItem, SubmissionItem]
+class MilestoneItem(TypedDict):
+    id: int
+    name: str
+    code: str
+    description: str
+    created_at: datetime.datetime
+
+
+__all__ = [LeaderboardItem, LeaderboardRankedEntry, RunItem, SubmissionItem, MilestoneItem]

--- a/src/libkernelbot/db_types.py
+++ b/src/libkernelbot/db_types.py
@@ -62,6 +62,7 @@ class MilestoneItem(TypedDict):
     code: str
     description: str
     created_at: datetime.datetime
+    exclude_gpus: list[str]
 
 
 __all__ = [LeaderboardItem, LeaderboardRankedEntry, RunItem, SubmissionItem, MilestoneItem]

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -310,6 +310,16 @@ class LeaderboardDB:
         )
         self.connection.commit()
 
+    def delete_milestones(self, leaderboard_id: int):
+        self.cursor.execute(
+            """
+            DELETE FROM leaderboard.milestones
+            WHERE leaderboard_id = %s;
+            """,
+            (leaderboard_id,),
+        )
+        self.connection.commit()
+
     def get_runs_generic(
         self, *, milestone_id: Optional[int] = None, submission_id: Optional[int] = None
     ) -> List["RunItem"]:

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -290,7 +290,7 @@ class LeaderboardDB:
             for row in self.cursor.fetchall()
         ]
 
-    def delete_milestone_runs(self, leaderboard_name: str):
+    def delete_milestone_runs(self, leaderboard_id: int):
         self.cursor.execute(
             """
             DELETE FROM leaderboard.runs
@@ -300,7 +300,7 @@ class LeaderboardDB:
                 WHERE leaderboard_id = %s
             );
             """,
-            (leaderboard_name,),
+            (leaderboard_id,),
         )
         self.connection.commit()
 

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -494,8 +494,8 @@ class LeaderboardDB:
             }
             self.cursor.execute(
                 """
-                INSERT INTO leaderboard.runs (submission_id, milestone_id, start_time, end_time, mode,
-                secret, runner, score, passed, compilation, meta, result, system_info
+                INSERT INTO leaderboard.runs (submission_id, milestone_id, start_time, end_time,
+                mode, secret, runner, score, passed, compilation, meta, result, system_info
                 )
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -29,6 +29,7 @@ class MilestoneData:
     name: str
     code: str
     description: str = ""
+    exclude_gpus: list[str] = dataclasses.field(default_factory=list)
 
 
 TestCaseType = Dict[str, Union[int, str]]

--- a/src/libkernelbot/task.py
+++ b/src/libkernelbot/task.py
@@ -24,6 +24,13 @@ class PythonTaskData:
     main: str
 
 
+@dataclasses.dataclass
+class MilestoneData:
+    name: str
+    code: str
+    description: str = ""
+
+
 TestCaseType = Dict[str, Union[int, str]]
 
 
@@ -110,6 +117,7 @@ class LeaderboardDefinition:
     task: LeaderboardTask
     description: str = ""
     templates: dict[str, str] = dataclasses.field(default_factory=dict)
+    milestones: list[MilestoneData] = dataclasses.field(default_factory=list)
 
 
 def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
@@ -137,6 +145,12 @@ def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
         else:
             file_dict[name] = (root / source).read_text()
 
+    milestones = []
+    for milestone in raw.get("milestones", []):
+        milestone["code"] = (root / milestone["source"]).read_text()
+        del milestone["source"]
+        milestones.append(MilestoneData(**milestone))
+
     raw["files"] = file_dict
 
     # load template files
@@ -146,10 +160,14 @@ def make_task_definition(yaml_file: str | Path) -> LeaderboardDefinition:
         templates[lang] = (root / source).read_text()
 
     del raw["templates"]
+    del raw["milestones"]
     description = raw["description"]
     del raw["description"]
     task = LeaderboardTask.from_dict(raw)
-    return LeaderboardDefinition(task=task, templates=templates, description=description)
+
+    return LeaderboardDefinition(
+        task=task, templates=templates, milestones=milestones, description=description
+    )
 
 
 def build_task_config(

--- a/src/libkernelbot/utils.py
+++ b/src/libkernelbot/utils.py
@@ -2,6 +2,9 @@ import logging
 import subprocess
 from typing import Any, Optional
 
+from libkernelbot.db_types import RunItem
+from libkernelbot.run_eval import RunResult
+
 
 def setup_logging(name: Optional[str] = None):
     """Configure and setup logging for the application"""
@@ -144,3 +147,7 @@ def limit_length(text: str, maxlen: int):
         return text[: maxlen - 6] + " [...]"
     else:
         return text
+
+
+def run_item_to_run_result(item: RunItem) -> RunResult:
+    return RunResult(**item["meta"], result=item["result"], passed=item["passed"])

--- a/src/migrations/20250725_01_hwite-add-milestone-table.py
+++ b/src/migrations/20250725_01_hwite-add-milestone-table.py
@@ -11,7 +11,8 @@ steps = [
         """
          CREATE TABLE IF NOT EXISTS leaderboard.milestones (
              id SERIAL PRIMARY KEY,
-             leaderboard_id INTEGER NOT NULL REFERENCES leaderboard.leaderboard(id) ON DELETE CASCADE,
+             leaderboard_id INTEGER NOT NULL REFERENCES leaderboard.leaderboard(id)
+                ON DELETE CASCADE,
              name TEXT NOT NULL,
              code TEXT NOT NULL,
              description TEXT,

--- a/src/migrations/20250725_01_hwite-add-milestone-table.py
+++ b/src/migrations/20250725_01_hwite-add-milestone-table.py
@@ -1,0 +1,61 @@
+"""
+Add milestone table for better milestone tracking
+"""
+
+from yoyo import step
+
+__depends__ = {"20250617_01_c5mrF-task-split"}  # Update to latest migration
+
+steps = [
+    step(
+        """
+         CREATE TABLE IF NOT EXISTS leaderboard.milestones (
+             id SERIAL PRIMARY KEY,
+             leaderboard_id INTEGER NOT NULL REFERENCES leaderboard.leaderboard(id) ON DELETE CASCADE,
+             name TEXT NOT NULL,
+             code TEXT NOT NULL,
+             description TEXT,
+             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+             UNIQUE(leaderboard_id, name)
+         )
+         """,
+        "DROP TABLE leaderboard.milestones",
+    ),
+    step("CREATE INDEX ON leaderboard.milestones (leaderboard_id)"),
+    # add alternative ID column that references milestones;
+    # we don't really care about being careful preserving milestone
+    # runs, so we can simply DELETE CASCADE
+    step(
+        """
+        ALTER TABLE leaderboard.runs
+        ADD COLUMN milestone_id INTEGER REFERENCES leaderboard.milestones(id) ON DELETE CASCADE;
+        """,
+        "ALTER TABLE leaderboard.runs DROP COLUMN milestone_id;",
+    ),
+    # as we now have two possible ids, exactly one of them can be NULL
+    step(
+        "ALTER TABLE leaderboard.runs ALTER COLUMN submission_id DROP NOT NULL;",
+        """
+         DELETE FROM leaderboard.runs WHERE submission_id IS NULL;
+         ALTER TABLE leaderboard.runs ALTER COLUMN submission_id SET NOT NULL;
+         """,
+    ),
+    step(
+        """
+        ALTER TABLE leaderboard.runs
+        ADD CONSTRAINT runs_single_parent CHECK (
+            (submission_id IS NOT NULL AND milestone_id IS NULL) OR
+            (submission_id IS NULL AND milestone_id IS NOT NULL)
+        );
+        """,
+        "ALTER TABLE leaderboard.runs DROP CONSTRAINT runs_single_parent;",
+    ),
+    # ensure we have fast indexing for regular submissions
+    step(
+        """
+        CREATE INDEX IF NOT EXISTS runs_submission_id_idx ON leaderboard.runs(submission_id)
+        WHERE submission_id IS NOT NULL;
+        """,
+        "DROP INDEX IF EXISTS leaderboard.runs_submission_id_idx",
+    ),
+]

--- a/src/migrations/20250726_01_j9Q3S-milestone-exclude-column.py
+++ b/src/migrations/20250726_01_j9Q3S-milestone-exclude-column.py
@@ -1,0 +1,14 @@
+"""
+Adds an exclude column to indicate that a milestone is not compatible with certain GPUs
+"""
+
+from yoyo import step
+
+__depends__ = {"20250725_01_hwite-add-milestone-table"}
+
+steps = [
+    step(
+        "ALTER TABLE leaderboard.milestones ADD COLUMN exclude_gpus TEXT NOT NULL DEFAULT '';",
+        "ALTER TABLE leaderboard.milestones DROP COLUMN exclude_gpus;",
+    )
+]


### PR DESCRIPTION
This is a heavily modified/updated version of #291 
It is rebased onto the libkernelbot changes, and uses a separate table to store milestone definitions as discussed.

The major design question that I'm not completely sure about is how to handle milestone runs.
In this version of the code, a `milestone_id` column is added to the runs table, and we set a constraint that enforces either submission or milestone id to be set. This is minimally invasive, but I wouldn't call it pretty. Contrary to what I  first thought, though, it doesn't require any changes to existing queries. In order to match runs to leaderboards, we need to join on submission_id, so all milestone runs get filtered out automatically. A good sign for this approach?

Alternatives could be to distinguish at the submission level (as in @PaliC 's original code), or to have two completely separate tables (claude says there is a postgres-specific extension that allows table inheritance, but i'm not really sure of the implications of this).

At this point, the implementation is fully functional, but could use some interface tweaks/improvements:
* API access; should be easy, the main functions are in backend
* display milestones as part of the leaderboard (?)
* automatic celebration message for beating a milestone the first time
* ~update-problems needs to become milestone-aware~ (implemented, but not really tested yet)