### PR TITLE
remove the non-exist field updated_at

### DIFF
--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -382,7 +382,7 @@ class LeaderboardDB:
                 WHERE submission_id = %s
                 AND status IN ('pending','running')
                 """,
-            (ts, sub_id),
+                (ts, sub_id),
             )
             self.connection.commit()
         except psycopg2.Error as e:


### PR DESCRIPTION
## Description

Remove non-exist field in the hearbeat update logic

even this has error, it does not affect the functionality of submission now, but may make us lose track of hearbeat of the job,

It's being used here, but exception is silence since it only used for hearbeat tracking
https://github.com/gpu-mode/discord-cluster-manager/blob/a992037eeb8763ce7b1f4d69ea06e41cf93b39c3/src/libkernelbot/background_submission_manager.py#L221

## Checklist

Before submitting this PR, ensure the following steps have been completed:

- [ ] Run the slash command `/verifyruns` on your own server.
  - Run the cluster bot on your server:
    ```bash
    python discord-bot.py
    ```
  - Start training runs with the slash command `/verifyruns`.
  - Verify that the bot eventually responds with:
    ```
    ✅ All runs completed successfully!
    ```
    (It may take a few minutes for all runs to finish. In particular, the GitHub
    runs may take a little longer. The Modal run is typically quick.)
  For more information on running a cluster bot on your own server, see
  README.md.
