### PR TITLE
leaderboard.submission add status columns

### DIFF
--- a/src/migrations/20260108_01_gzSm3-add-submission-status.py
+++ b/src/migrations/20260108_01_gzSm3-add-submission-status.py
@@ -1,0 +1,22 @@
+"""
+add_submission_status
+"""
+
+from yoyo import step
+
+__depends__ = {'20251106_01_kOjGy-draft-code-editor'}
+
+steps = [
+    step(
+        # forward
+        """
+        ALTER TABLE leaderboard.submission
+        ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+        """,
+        # backward for rollback if yoyo apply fails for any reason
+        """
+        ALTER TABLE leaderboard.submission
+        DROP COLUMN status;
+        """
+    )
+]


### PR DESCRIPTION
add  status column for submission table

this is mainly used to define the status of the submission, right now we only have two conditions:
- ACTIVE:  this is default value when a submission record is created, active submission is considered valid submission for rankings in competitions
- INACTIVE: this can only changed by admins of gpumode, inactive submission is ignored for rankings in competitions, this is a soft-delete operation



followup fe change: https://github.com/gpu-mode/kernelboard/pull/107