### PR TITLE
Add db change to leaderboard and runs for admin control

### DIFF
--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -12,7 +12,6 @@ steps = [
         ALTER TABLE leaderboard.leaderboard
           ADD COLUMN status TEXT DEFAULT 'active',
           ADD COLUMN config JSONB,
-          ADD COLUMN start_time TIMESTAMPTZ,
           ADD COLUMN last_modified TIMESTAMPTZ;
         """,
         """
@@ -26,7 +25,7 @@ steps = [
     step(
         """
         ALTER TABLE leaderboard.runs
-          ADD COLUMN status TEXT DEFAULT 'pending';
+          ADD COLUMN status TEXT DEFAULT 'active';
         """,
         """
         ALTER TABLE leaderboard.runs

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -1,0 +1,32 @@
+"""
+admin_db
+"""
+
+from yoyo import step
+
+__depends__ = {'20260108_01_gzSm3-add-submission-status'}
+
+steps = [
+    step(
+        """
+        ALTER TABLE leaderboard.leaderboard
+          ADD COLUMN status DEFAULT 'active',
+          ADD COLUMN config JSONB;
+        """,
+        """
+        ALTER TABLE leaderboard.leaderboard
+          DROP COLUMN IF EXISTS config,
+          DROP COLUMN IF EXISTS status;
+        """
+    ),
+    step(
+        """
+        ALTER TABLE leaderboard.runs
+          ADD COLUMN status TEXT DEFAULT 'active';
+        """,
+        """
+        ALTER TABLE leaderboard.runs
+          DROP COLUMN IF EXISTS status;
+        """
+    ),
+]

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -6,6 +6,8 @@ from yoyo import step
 
 __depends__ = {'20260108_01_gzSm3-add-submission-status'}
 
+from yoyo import step
+
 steps = [
     step(
         """
@@ -26,10 +28,12 @@ steps = [
     step(
         """
         ALTER TABLE leaderboard.runs
-          ADD COLUMN status TEXT DEFAULT 'active' NOT NULL;
+          ADD COLUMN status TEXT DEFAULT 'active' NOT NULL,
+          ADD COLUMN group_id TEXT;
         """,
         """
         ALTER TABLE leaderboard.runs
+          DROP COLUMN IF EXISTS group_id,
           DROP COLUMN IF EXISTS status;
         """
     ),

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -10,7 +10,7 @@ steps = [
     step(
         """
         ALTER TABLE leaderboard.leaderboard
-          ADD COLUMN status DEFAULT 'active',
+          ADD COLUMN status TEXT DEFAULT 'active',
           ADD COLUMN config JSONB;
         """,
         """

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -10,7 +10,7 @@ steps = [
     step(
         """
         ALTER TABLE leaderboard.leaderboard
-          ADD COLUMN status TEXT DEFAULT 'active',
+          ADD COLUMN status TEXT DEFAULT 'active' NOT NULL,
           ADD COLUMN config JSONB,
           ADD COLUMN last_modified TIMESTAMPTZ;
         """,
@@ -24,7 +24,7 @@ steps = [
     step(
         """
         ALTER TABLE leaderboard.runs
-          ADD COLUMN status TEXT DEFAULT 'pending';
+          ADD COLUMN status TEXT DEFAULT 'active' NOT NULL;
         """,
         """
         ALTER TABLE leaderboard.runs

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -24,7 +24,7 @@ steps = [
     step(
         """
         ALTER TABLE leaderboard.runs
-          ADD COLUMN status TEXT DEFAULT 'active';
+          ADD COLUMN status TEXT DEFAULT 'pending';
         """,
         """
         ALTER TABLE leaderboard.runs

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -12,7 +12,7 @@ steps = [
         ALTER TABLE leaderboard.leaderboard
           ADD COLUMN status TEXT DEFAULT 'active' NOT NULL,
           ADD COLUMN config JSONB,
-          ADD COLUMN start_at TIMESTAMPTZ;
+          ADD COLUMN start_at TIMESTAMPTZ,
           ADD COLUMN last_modified TIMESTAMPTZ;
         """,
         """

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -17,7 +17,6 @@ steps = [
         """
         ALTER TABLE leaderboard.leaderboard
           DROP COLUMN IF EXISTS last_modified,
-          DROP COLUMN IF EXISTS start_time,
           DROP COLUMN IF EXISTS config,
           DROP COLUMN IF EXISTS status;
         """

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -11,10 +11,14 @@ steps = [
         """
         ALTER TABLE leaderboard.leaderboard
           ADD COLUMN status TEXT DEFAULT 'active',
-          ADD COLUMN config JSONB;
+          ADD COLUMN config JSONB,
+          ADD COLUMN start_time TIMESTAMPTZ,
+          ADD COLUMN last_modified TIMESTAMPTZ;
         """,
         """
         ALTER TABLE leaderboard.leaderboard
+          DROP COLUMN IF EXISTS last_modified,
+          DROP COLUMN IF EXISTS start_time,
           DROP COLUMN IF EXISTS config,
           DROP COLUMN IF EXISTS status;
         """
@@ -22,7 +26,7 @@ steps = [
     step(
         """
         ALTER TABLE leaderboard.runs
-          ADD COLUMN status TEXT DEFAULT 'active';
+          ADD COLUMN status TEXT DEFAULT 'pending';
         """,
         """
         ALTER TABLE leaderboard.runs

--- a/src/migrations/20260202_01_s3s1B-admin-db.py
+++ b/src/migrations/20260202_01_s3s1B-admin-db.py
@@ -12,11 +12,13 @@ steps = [
         ALTER TABLE leaderboard.leaderboard
           ADD COLUMN status TEXT DEFAULT 'active' NOT NULL,
           ADD COLUMN config JSONB,
+          ADD COLUMN start_at TIMESTAMPTZ;
           ADD COLUMN last_modified TIMESTAMPTZ;
         """,
         """
         ALTER TABLE leaderboard.leaderboard
           DROP COLUMN IF EXISTS last_modified,
+          DROP COLUMN IF EXISTS start_at,
           DROP COLUMN IF EXISTS config,
           DROP COLUMN IF EXISTS status;
         """


### PR DESCRIPTION
leaderboard
- status : default 'active', top control for leaderboard. as long as  startTime<= Time <= endtime, the leaderboard visibility and submission is based on startTime and endTime.
- config: a json object to store additional configuration for a leaderboard
- start_at: when the competition start (optional), if not set, then start immediately once leaderboard is 'active'
- last_modified: track when was laster the leaderboard has changes

runs
- status: default 'active',  this is used when we have backfill
- group_id: group runs that belongs to one run attempt