### PR TITLE
Add user-specific rate limits with admin API management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ reference-kernels/
 yoyo.ini
 .venv
 .claude/
+*.egg-info/

--- a/src/migrations/20260208_01_RkLmN-add-user-rate-limits.py
+++ b/src/migrations/20260208_01_RkLmN-add-user-rate-limits.py
@@ -1,0 +1,27 @@
+"""
+add-user-rate-limits
+"""
+
+from yoyo import step
+
+__depends__ = {'20260108_01_gzSm3-add-submission-status'}
+
+steps = [
+    step(
+        # forward
+        """
+        CREATE TABLE leaderboard.user_rate_limits (
+            user_id TEXT PRIMARY KEY REFERENCES leaderboard.user_info(id),
+            max_submissions_per_hour INTEGER,
+            max_submissions_per_day INTEGER,
+            note TEXT,
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        );
+        """,
+        # backward
+        """
+        DROP TABLE leaderboard.user_rate_limits;
+        """
+    )
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def _nuke_contents(db):
     db.cursor.execute(
         "TRUNCATE leaderboard.code_files, leaderboard.submission, leaderboard.runs, "
         "leaderboard.leaderboard, leaderboard.user_info, leaderboard.templates, "
-        "leaderboard.gpu_type RESTART IDENTITY CASCADE"
+        "leaderboard.gpu_type, leaderboard.user_rate_limits RESTART IDENTITY CASCADE"
     )
     db.connection.commit()
 


### PR DESCRIPTION
Introduces per-user submission rate limiting (hourly and daily caps)
configurable via the admin API. Users without an override are unrestricted.

- New migration: leaderboard.user_rate_limits table
- DB methods: get/set/delete user rate limits + submission rate checking
- Admin endpoints: GET/PUT/DELETE /admin/rate-limits/{user_id}
- Both submission endpoints check user rate limits (return 429 if exceeded)
- Tests for DB methods and all API endpoints

https://claude.ai/code/session_01LiSWKfcKe4riGZwMYdubiJ