### PR TITLE
Fix Modal CUTLASS header tag

### DIFF
--- a/src/runners/modal_runner.py
+++ b/src/runners/modal_runner.py
@@ -71,7 +71,7 @@ cuda_image = (
     )
     # CUTLASS C++ headers for #include <cutlass/...>
     .run_commands(
-        "git clone --depth 1 --branch v4.5.2 https://github.com/NVIDIA/cutlass.git /opt/cutlass",
+        "git clone --depth 1 --branch v4.5.1 https://github.com/NVIDIA/cutlass.git /opt/cutlass",
     )
     .env({
         "CUTLASS_PATH": "/opt/cutlass",


### PR DESCRIPTION
Fixes the Modal image build after the dependency update.

`nvidia-cutlass-dsl==4.5.2` exists on PyPI, but `NVIDIA/cutlass` does not have a matching `v4.5.2` repository tag. The newest available CUTLASS repo tag is `v4.5.1`, so this updates the header checkout to that tag while leaving the Python CuTe DSL package at `4.5.2` from the previous PR.

Validation:
- `python -m py_compile src/runners/modal_runner.py`
- `git diff --check`
