### PR TITLE
Hide submissions with any failed secret run

### DIFF
--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -890,7 +890,6 @@ class LeaderboardDB:
                         WHERE sr.submission_id = s.id
                             AND sr.secret
                             AND sr.runner = r.runner
-                            AND sr.mode = r.mode
                             AND sr.passed = FALSE
                     )
                 ORDER BY r.score ASC
@@ -920,7 +919,6 @@ class LeaderboardDB:
                               WHERE sr.submission_id = s.id
                                   AND sr.secret
                                   AND sr.runner = r.runner
-                                  AND sr.mode = r.mode
                                   AND sr.passed = FALSE
                           )
                     ORDER BY s.user_id, r.score ASC
@@ -1272,7 +1270,6 @@ class LeaderboardDB:
                         WHERE sr.submission_id = r.submission_id
                             AND sr.secret
                             AND sr.runner = r.runner
-                            AND sr.mode = r.mode
                             AND sr.passed = FALSE
                     )
             """
@@ -1419,7 +1416,6 @@ class LeaderboardDB:
                         WHERE sr.submission_id = s.id
                             AND sr.secret
                             AND sr.runner = r.runner
-                            AND sr.mode = r.mode
                             AND sr.passed = FALSE
                     )
                 """
@@ -1441,7 +1437,6 @@ class LeaderboardDB:
                         WHERE sr.submission_id = s.id
                             AND sr.secret
                             AND sr.runner = r.runner
-                            AND sr.mode = r.mode
                             AND sr.passed = FALSE
                     )
                 """

--- a/tests/test_leaderboard_db.py
+++ b/tests/test_leaderboard_db.py
@@ -410,6 +410,40 @@ def test_failed_secret_run_hides_submission_from_rankings(database, submit_leade
         assert db.get_leaderboard_submission_count("submit-leaderboard", "A100", "5") == 0
 
 
+def test_failed_secret_benchmark_hides_public_leaderboard_score(database, submit_leaderboard):
+    submit_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    failed_secret = dataclasses.replace(sample_run_result(), passed=False)
+
+    with database as db:
+        hacked = db.create_submission(
+            "submit-leaderboard", "fast.py", 5, "fast", submit_time, user_name="user5"
+        )
+        _create_submission_run(db, hacked, mode="leaderboard", runner="A100", score=1.0)
+        _create_submission_run(
+            db,
+            hacked,
+            mode="benchmark",
+            secret=True,
+            runner="A100",
+            score=None,
+            result=failed_secret,
+        )
+        db.mark_submission_done(hacked)
+
+        valid = db.create_submission(
+            "submit-leaderboard", "valid.py", 6, "valid", submit_time, user_name="user6"
+        )
+        _create_submission_run(db, valid, mode="leaderboard", runner="A100", score=2.0)
+        _create_submission_run(db, valid, mode="benchmark", secret=True, runner="A100")
+        db.mark_submission_done(valid)
+
+    with database as db:
+        ranked = db.get_leaderboard_submissions("submit-leaderboard", "A100")
+        assert [row["submission_id"] for row in ranked] == [valid]
+        assert db.get_leaderboard_submission_count("submit-leaderboard", "A100") == 1
+        assert db.get_leaderboard_submission_count("submit-leaderboard", "A100", "5") == 0
+
+
 def test_failed_secret_run_hides_user_submission_scores(database, submit_leaderboard):
     submit_time = datetime.datetime.now(tz=datetime.timezone.utc)
     failed_secret = dataclasses.replace(sample_run_result(), passed=False)


### PR DESCRIPTION
## Summary
- hide public leaderboard scores when the same submission has any failed secret run for that runner
- add a regression for the QR failure mode: public `leaderboard` passes, secret `benchmark` fails

## Why
PR #490 only filtered failed secret runs with the same mode as the public scored run. QR submissions can fail secret `benchmark` before producing a secret `leaderboard` run, while still having a passing public `leaderboard` score. Those should not appear on rankings.

## Validation
- `uv run --extra dev pytest -q tests/test_leaderboard_db.py -k 'failed_secret or leaderboard_submission_ranked or leaderboard_submission_count'`
- `uv run --extra dev python -m py_compile src/libkernelbot/leaderboard_db.py`
- `git diff --check`
- verified the updated SQL excludes prod submissions `800895`, `800582`, and `800601`
