### PR TITLE
Extend Modal runner timeout

### DIFF
--- a/src/runners/modal_runner.py
+++ b/src/runners/modal_runner.py
@@ -85,6 +85,8 @@ cuda_image = cuda_image.add_local_python_source(
     "modal_runner_archs",
 )
 
+MODAL_RUN_TIMEOUT_SECONDS = 60 * 60
+
 
 class TimeoutException(Exception):
     pass
@@ -111,7 +113,7 @@ def timeout(seconds: int):
 
 def modal_run_config(  # noqa: C901
     config: dict,
-    timeout_seconds: int = 600,
+    timeout_seconds: int = MODAL_RUN_TIMEOUT_SECONDS,
 ) -> FullResult:
     """Modal version of run_pytorch_script, handling timeouts"""
     try:

--- a/src/runners/modal_runner_archs.py
+++ b/src/runners/modal_runner_archs.py
@@ -1,13 +1,21 @@
 # This file contains wrapper functions for running
 # Modal apps on specific devices. We will fix this later.
-from modal_runner import app, cuda_image, modal_run_config
+from modal_runner import MODAL_RUN_TIMEOUT_SECONDS, app, cuda_image, modal_run_config
 
 gpus = ["T4", "L4", "L4:4", "A100-80GB", "H100!", "B200"]
 for gpu in gpus:
     gpu_slug = gpu.lower().split("-")[0].strip("!").replace(":", "x")
-    app.function(gpu=gpu, image=cuda_image, name=f"run_cuda_script_{gpu_slug}", serialized=True)(
-        modal_run_config
-    )
-    app.function(gpu=gpu, image=cuda_image, name=f"run_pytorch_script_{gpu_slug}", serialized=True)(
-        modal_run_config
-    )
+    app.function(
+        gpu=gpu,
+        image=cuda_image,
+        name=f"run_cuda_script_{gpu_slug}",
+        serialized=True,
+        timeout=MODAL_RUN_TIMEOUT_SECONDS,
+    )(modal_run_config)
+    app.function(
+        gpu=gpu,
+        image=cuda_image,
+        name=f"run_pytorch_script_{gpu_slug}",
+        serialized=True,
+        timeout=MODAL_RUN_TIMEOUT_SECONDS,
+    )(modal_run_config)


### PR DESCRIPTION
## Summary
- Set Modal runner functions to a one-hour platform timeout.
- Match kernelbot's in-function alarm timeout to the same one-hour envelope.

## Root Cause
Production Modal logs for `discord-bot-runner` show B200 runner inputs being cancelled at Modal's default 300 second function timeout, including a cancellation at `2026-06-18 22:19:32 UTC` that lines up with the `814188` failure window:

```text
Task's current input ... hit its timeout of 300s
[modal-client] Received a cancellation signal while processing input ...
[modal-client] Successfully canceled input ...
```

The deployed runner functions were registered without a Modal `timeout=` argument, so the platform default could cancel the function before kernelbot's own timeout handling ran. Raising only the Modal platform timeout is not enough because `modal_run_config` still had an internal 600s alarm; this PR sets both to the same one-hour envelope.

## Validation
- `uv run ruff check src/runners/modal_runner.py src/runners/modal_runner_archs.py`
- `uv run python -m py_compile src/runners/modal_runner.py src/runners/modal_runner_archs.py`
- `git diff --check`

## Deployment Note
After merge, the Modal runner app needs to be redeployed so the new function-level `timeout=3600` is applied. Deploying only the Northflank service is not enough for this part.
