### PR TITLE
Expose submission job status to users

### DIFF
--- a/src/kernelbot/api/main.py
+++ b/src/kernelbot/api/main.py
@@ -1008,6 +1008,11 @@ async def get_user_submission(
                 "done": submission["done"],
                 "code": submission["code"],
                 "runs": [{k: r[k] for k in run_fields} for r in submission["runs"]],
+                "job": {
+                    "status": submission.get("job_status"),
+                    "error": submission.get("job_error"),
+                    "last_heartbeat": submission.get("job_last_heartbeat"),
+                },
             }
     except HTTPException:
         raise

--- a/src/libkernelbot/db_types.py
+++ b/src/libkernelbot/db_types.py
@@ -60,6 +60,9 @@ class SubmissionItem(TypedDict):
     done: bool
     code: str
     runs: List[RunItem]
+    job_status: NotRequired[Optional[str]]
+    job_error: NotRequired[Optional[str]]
+    job_last_heartbeat: NotRequired[Optional[datetime.datetime]]
 
 
 class RateLimitItem(TypedDict):

--- a/src/libkernelbot/leaderboard_db.py
+++ b/src/libkernelbot/leaderboard_db.py
@@ -1368,10 +1368,12 @@ class LeaderboardDB:
     def get_submission_by_id(self, submission_id: int) -> Optional["SubmissionItem"]:
         query = """
                 SELECT s.leaderboard_id, lb.name, s.file_name, s.user_id,
-                       s.submission_time, s.done, c.code
+                       s.submission_time, s.done, c.code,
+                       js.status, js.error, js.last_heartbeat
                 FROM leaderboard.submission s
                 JOIN leaderboard.code_files c ON s.code_id = c.id
                 JOIN leaderboard.leaderboard lb ON s.leaderboard_id = lb.id
+                LEFT JOIN leaderboard.submission_job_status js ON js.submission_id = s.id
                 WHERE s.id = %s
                 """
         self.cursor.execute(query, (submission_id,))
@@ -1416,6 +1418,9 @@ class LeaderboardDB:
             done=submission[5],
             code=bytes(submission[6]).decode("utf-8"),
             runs=runs,
+            job_status=submission[7],
+            job_error=submission[8],
+            job_last_heartbeat=submission[9],
         )
 
     def get_leaderboard_submission_count(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -172,6 +172,9 @@ async def test_submit_leaderboard(bot: backend.KernelBackend, task_directory):
             "code": "pass",
             "done": False,
             "file_name": "submit.py",
+            "job_error": None,
+            "job_last_heartbeat": None,
+            "job_status": None,
             "leaderboard_id": s_id,
             "leaderboard_name": "submit-leaderboard",
             "runs": [
@@ -279,6 +282,9 @@ async def test_submit_full(bot: backend.KernelBackend, task_directory):
             "code": "pass",
             "done": True,
             "file_name": "submission.py",
+            "job_error": None,
+            "job_last_heartbeat": None,
+            "job_status": None,
             "leaderboard_id": 1,
             "leaderboard_name": "submit-leaderboard",
             "runs": [

--- a/tests/test_leaderboard_db.py
+++ b/tests/test_leaderboard_db.py
@@ -199,6 +199,16 @@ def test_leaderboard_submission_basic(database, submit_leaderboard):
         assert submission["done"] is False
         assert submission["code"] == dangerous_code
         assert submission["runs"] == []
+        assert submission["job_status"] is None
+        assert submission["job_error"] is None
+        assert submission["job_last_heartbeat"] is None
+
+        heartbeat = datetime.datetime.now(tz=datetime.timezone.utc)
+        db.upsert_submission_job_status(sub_id, "running", "still working", heartbeat)
+        submission = db.get_submission_by_id(sub_id)
+        assert submission["job_status"] == "running"
+        assert submission["job_error"] == "still working"
+        assert submission["job_last_heartbeat"] == heartbeat
 
     # add a submission run
     run_result = sample_run_result()


### PR DESCRIPTION
## Summary
- Include background job status on the authenticated user submission detail endpoint
- Preserve the existing submission response shape and add a nullable `job` object
- Add DB coverage for submissions with and without job status

## Test
- `uv run pytest tests/test_leaderboard_db.py tests/test_admin_api.py -q`