### PR TITLE
eval: hand kernel a fresh input each timed iteration (close result-replay in scored path)

### DIFF
--- a/examples/eval.py
+++ b/examples/eval.py
@@ -256,6 +256,7 @@ def _run_single_benchmark(test: TestCase, recheck: bool, max_repeats: int, max_t
     durations = []
     # generate input data once
     data = generate_input(**test.args)
+    bench_template = data  # kept as a template for fresh per-iteration copies (anti-replay)
     check_copy = _clone_data(data, 0)
     #  first, one obligatory correctness check
     output = custom_kernel(data)
@@ -268,6 +269,14 @@ def _run_single_benchmark(test: TestCase, recheck: bool, max_repeats: int, max_t
     # otherwise, we repeat until we either measure at least 10 full seconds,
     # or the relative error of the mean is below 1%.
 
+    # ANTI-REPLAY: even in the non-recheck (ranked/benchmark) path, hand the kernel a FRESH
+    # tensor object every timed iteration. Without this, the same `data` object is reused, so a
+    # submission can cache on the first call (keyed on object identity / .data_ptr() / ._version)
+    # and return the cached output with zero compute for all timed iterations -- the dominant
+    # "result replay" hack family. The clone happens OUTSIDE the timed region (before
+    # start_event.record()), so it does not inflate the measured kernel time. We retain the two
+    # most recent inputs so the caching allocator cannot immediately recycle a freed data_ptr.
+    _recent_inputs = []
     bm_start_time = time.perf_counter_ns()
     for i in range(max_repeats):
         if recheck:
@@ -277,6 +286,11 @@ def _run_single_benchmark(test: TestCase, recheck: bool, max_repeats: int, max_t
 
             data = generate_input(**test.args)
             check_copy = _clone_data(data, 0)
+        else:
+            data = _clone_data(bench_template, 0)
+            _recent_inputs.append(data)
+            if len(_recent_inputs) > 2:
+                _recent_inputs.pop(0)
         torch.cuda.synchronize()
         start_event = torch.cuda.Event(enable_timing=True)
         end_event = torch.cuda.Event(enable_timing=True)


### PR DESCRIPTION
## Problem

`examples/eval.py::_run_single_benchmark` runs the **scored** (benchmark / leaderboard) path with `recheck=False`: it calls `generate_input()` **once**, checks correctness **once**, then invokes `custom_kernel(data)` for all `max_repeats` timed iterations **on the same `data` object** (same `id()`, same `.data_ptr()`).

This leaves the dominant "result replay" hack open in the ranked path: a submission can cache the output on the first call (keyed on object identity / `.data_ptr()` / `._version`) and return it with zero compute for every timed iteration, reporting an enormous false speedup. (Test mode already uses `recheck=True`, but the ranked timing does not.)

## Fix

In the non-recheck timed loop, hand the kernel a **fresh tensor clone each iteration** (new object + new `data_ptr()`). The clone happens **outside** the timed region (before `start_event.record()`), so the measured kernel time is unaffected. The two most recent inputs are retained so the caching allocator can't immediately recycle a freed `data_ptr`.

This defeats identity / `._version` / pointer-based result replay in the scored path at negligible (untimed) cost.

A stronger alternative (already supported by the harness) is to default `recheck=True` for ranked, which additionally re-generates with a fresh seed and re-checks correctness every iteration; the clone approach is the minimal, low-overhead fix that closes the replay vector specifically.

Marking as **draft** for discussion.
