### PR TITLE
Add cuTile (cuda-tile[tileiras]) to the Modal CUDA image

### DIFF
--- a/src/runners/modal_runner.py
+++ b/src/runners/modal_runner.py
@@ -62,6 +62,11 @@ cuda_image = (
         "nvidia-cutlass-dsl==4.5.2",
         "cuda-core[cu13]",
         "cuda-python[all]==13.0",
+        # cuTile: the CUDA Tile programming model in Python (`import cuda.tile`).
+        # The [tileiras] extra adds the Tile IR assembler so kernels can be
+        # compiled in-process. tileiras 13.2+ targets Blackwell and Ampere/Ada
+        # and needs driver r580+, both satisfied by the B200 runners.
+        "cuda-tile[tileiras]==1.4.0",
         # "nvmath-python[cu13]~=0.4",
         # "numba-cuda[cu13]~=0.15",
     )


### PR DESCRIPTION
## What

Adds NVIDIA's **cuTile** Python tile-programming model to the shared Modal `cuda_image` in `src/runners/modal_runner.py`, so submissions can `import cuda.tile`:

```python
"cuda-tile[tileiras]==1.4.0",
```

Placed in the existing *nvidia cuda packages* `uv_pip_install` block, **before** the `torch==2.12.0` step so torch's CUDA/NCCL dependency set still wins last (per the comment already in the file).

## Why

cuTile (`cuda.tile`) is NVIDIA's tile-based kernel DSL — arrays/tiles/blocks, compiled through Tile IR — and is a natural tool for the kind of dense-linear-algebra problems the leaderboard hosts. It isn't installed on the runner today.

I confirmed the absence empirically with a probe submission to the **`eigh`** leaderboard (B200, `--mode test`): `import cuda.tile` raises `ModuleNotFoundError`, and the `cuda` namespace package exposes only `bindings, core, pathfinder`. The probe also reported the runner as Python `3.13.0`, torch `2.12.0+cu130`, CUDA `13.0` — consistent with this image definition.

## Package details

- cuTile is published on PyPI as **`cuda-tile`** (current release **1.4.0**, `requires-python >=3.10,<3.15`). It ships a `cp313` `manylinux2014_x86_64` wheel, matching the image's `add_python="3.13"`.
- **`tileiras` is not a standalone package** — it's the **`[tileiras]` extra** of `cuda-tile`, which pulls `cuda-toolkit[nvcc,nvvm,tileiras]>=13.2,<13.4` (the Tile IR assembler, so kernels can be compiled in-process rather than needing a separate system CUDA toolkit). `cuda-tile[tileiras]` is the package the question "install cuTile + tileiras" maps to.
- Hardware/driver: tileiras 13.2+ targets **Blackwell (B200)** and Ampere/Ada and requires driver **r580+** — satisfied by the B200 runners. (Older GPUs in `modal_runner_archs.py` — T4/L4/A100 — predate cuTile codegen support; this only adds the package, it doesn't make those runners able to *run* tile kernels.)

## Risks / things a maintainer should weigh (I could not test these locally)

1. **Dependency resolution.** The `[tileiras]` extra wants `cuda-toolkit` in `[13.2, 13.4)`, while the image already pins `cuda-python[all]==13.0` (which pins `cuda-bindings~=13.0`). These are different distributions (`cuda-toolkit` vs `cuda-python`/`cuda-bindings`) so they *shouldn't* collide, but the two install steps share one uv resolution environment — please confirm `uv pip install` resolves cleanly when the image rebuilds. If it doesn't, the alternative is the bare `cuda-tile==1.4.0` (no extra) plus relying on the system CUDA already in the `nvidia/cuda:12.9.1-devel` base, though note the base is CUDA 12.9 while tileiras wants 13.2+.
2. **Blast radius.** `cuda_image` is shared by **every** GPU/runner, and `modal-deploy.yml` redeploys it on merge to `main`/`dev`. This adds a sizable dependency (cuTile + a 13.2 toolkit slice) to the image used for all problems. Worth a rebuild-time/image-size check.

Happy to adjust the pin, drop the `[tileiras]` extra, or gate this behind a separate image if you'd prefer to limit it to the Blackwell runners.