### PR TITLE
Add CUTLASS DSL to Helion runner image

### DIFF
--- a/docker/helion.Dockerfile
+++ b/docker/helion.Dockerfile
@@ -83,14 +83,13 @@ RUN sudo uv pip install --system \
 # # tinygrad
 # RUN sudo uv pip install --system tinygrad~=0.10
 
-# # NVIDIA CUDA packages
-# RUN sudo uv pip install --system \
-#     nvidia-cupynumeric~=25.3 \
-#     nvidia-cutlass-dsl==4.3.5 \
-#     "cuda-core[cu13]" \
-#     "cuda-python[all]==13.0"
+# NVIDIA CUDA/CUTLASS packages for CuTe DSL submissions
+RUN sudo uv pip install --system \
+    nvidia-cutlass-dsl==4.5.2 \
+    "cuda-core[cu13]" \
+    "cuda-python[all]==13.0"
 
-# # CUTLASS C++ headers
-# RUN git clone --depth 1 --branch v4.3.5 https://github.com/NVIDIA/cutlass.git /opt/cutlass
-# ENV CUTLASS_PATH=/opt/cutlass
-# ENV CPLUS_INCLUDE_PATH=/opt/cutlass/include:/opt/cutlass/tools/util/include
+# CUTLASS C++ headers
+RUN git clone --depth 1 --branch v4.5.1 https://github.com/NVIDIA/cutlass.git /opt/cutlass
+ENV CUTLASS_PATH=/opt/cutlass
+ENV CPLUS_INCLUDE_PATH=/opt/cutlass/include:/opt/cutlass/tools/util/include


### PR DESCRIPTION
## Summary
- install `nvidia-cutlass-dsl==4.5.2`, `cuda-core[cu13]`, and `cuda-python[all]==13.0` in the Helion runner image
- install CUTLASS v4.5.1 C++ headers under `/opt/cutlass`
- export `CUTLASS_PATH` and `CPLUS_INCLUDE_PATH` so CUDA extension builds can find CUTLASS headers

## Why
The hosted B200/Brev profiling runtime currently cannot run CuTe DSL submissions because `import cutlass`, `import cuda`, and `import cuda.bindings` fail with `ModuleNotFoundError`. The Modal runner already carries this dependency stack; this enables the same CuTe/CUTLASS path for the Helion runner image.

## Validation
- `git diff --check`
- resolved the added package set with `uv pip compile` for Python 3.13 on `x86_64-manylinux_2_28` using binary wheels only