### PR TITLE
Skip trashtalk for beginner problems

### DIFF
--- a/src/kernelbot/cogs/top_three_cog.py
+++ b/src/kernelbot/cogs/top_three_cog.py
@@ -9,6 +9,19 @@ from libkernelbot.utils import setup_logging
 
 logger = setup_logging(__name__)
 
+BEGINNER_LEADERBOARDS = frozenset(
+    {
+        "conv2d_v2",
+        "grayscale_v2",
+        "histogram_v2",
+        "matmul_v2",
+        "prefixsum_v2",
+        "sort_v2",
+        "vectoradd_v2",
+        "vectorsum_v2",
+    }
+)
+
 
 class TopThreeCog(commands.Cog):
     """Announce leaderboard podium changes, including API-originated submissions."""
@@ -27,7 +40,11 @@ class TopThreeCog(commands.Cog):
         now = datetime.datetime.now(datetime.timezone.utc)
         with self.bot.leaderboard_db as db:
             for leaderboard in db.get_leaderboards():
-                if leaderboard["visibility"] != "public" or leaderboard["deadline"] <= now:
+                if (
+                    leaderboard["name"] in BEGINNER_LEADERBOARDS
+                    or leaderboard["visibility"] != "public"
+                    or leaderboard["deadline"] <= now
+                ):
                     continue
                 for gpu_type in leaderboard["gpu_types"]:
                     key = (leaderboard["name"], gpu_type)

--- a/tests/test_top_three.py
+++ b/tests/test_top_three.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from kernelbot.cogs.top_three_cog import TopThreeCog
+from kernelbot.cogs.top_three_cog import BEGINNER_LEADERBOARDS, TopThreeCog
 from kernelbot.top_three import (
     EVICTION_LINES,
     detect_podium_change,
@@ -85,6 +85,40 @@ def test_display_name_uses_public_leaderboard_username_without_ping():
 def test_trashtalk_has_variety():
     assert len(EVICTION_LINES) >= 8
     assert len(set(EVICTION_LINES)) == len(EVICTION_LINES)
+
+
+def test_watcher_does_not_read_beginner_leaderboard_standings():
+    deadline = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+    beginner_leaderboards = [
+        {
+            "name": name,
+            "gpu_types": ["B200"],
+            "visibility": "public",
+            "deadline": deadline,
+        }
+        for name in BEGINNER_LEADERBOARDS
+    ]
+    regular_leaderboard = {
+        "name": "flash_attention",
+        "gpu_types": ["H100", "B200"],
+        "visibility": "public",
+        "deadline": deadline,
+    }
+    db = Mock()
+    db.get_leaderboards.return_value = [*beginner_leaderboards, regular_leaderboard]
+    bot = Mock()
+    bot.leaderboard_db.__enter__ = Mock(return_value=db)
+    bot.leaderboard_db.__exit__ = Mock(return_value=False)
+
+    watcher = object.__new__(TopThreeCog)
+    watcher.bot = bot
+
+    standings = watcher._read_standings()
+
+    assert set(standings) == {("flash_attention", "H100"), ("flash_attention", "B200")}
+    assert db.get_leaderboard_submissions.call_count == 2
+    db.get_leaderboard_submissions.assert_any_call("flash_attention", "H100", limit=3)
+    db.get_leaderboard_submissions.assert_any_call("flash_attention", "B200", limit=3)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- exclude the eight beginner `_v2` leaderboards from the top-three trashtalk watcher
- skip them before querying per-GPU standings
- retain polling and announcements for normal public, active leaderboards

## Why

The beginner leaderboards are high-volume introductory problems where podium-change trashtalk is not useful. The watcher previously treated them like every other active public leaderboard.

## Validation

- `uv run pytest tests/test_top_three.py` (12 passed)
- `uv run ruff check src/kernelbot/cogs/top_three_cog.py tests/test_top_three.py`
