### PR TITLE
Use Modal async API to remove executor concurrency bottleneck

### DIFF
--- a/src/libkernelbot/launchers/modal.py
+++ b/src/libkernelbot/launchers/modal.py
@@ -20,7 +20,6 @@ class ModalLauncher(Launcher):
     async def run_submission(
         self, config: dict, gpu_type: GPU, status: RunProgressReporter
     ) -> FullResult:
-        loop = asyncio.get_event_loop()
         if config["lang"] == "cu":
             config["include_dirs"] = config.get("include_dirs", []) + self.additional_include_dirs
         func_name = self._function_name(config, gpu_type)
@@ -29,10 +28,8 @@ class ModalLauncher(Launcher):
 
         await status.push("⏳ Waiting for Modal run to finish...")
 
-        result = await loop.run_in_executor(
-            None,
-            lambda: modal.Function.from_name("discord-bot-runner", func_name).remote(config=config),
-        )
+        function = modal.Function.from_name("discord-bot-runner", func_name)
+        result = await function.remote.aio(config=config)
 
         await status.update("✅ Waiting for modal run to finish... Done")
 

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Tuple
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,6 +27,26 @@ class MockProgressReporter(RunProgressReporter):
 
     async def update(self, message: str):
         self.updates.append(message)
+
+
+@pytest.mark.asyncio
+async def test_modal_submission_uses_native_async_api():
+    launcher = ModalLauncher(add_include_dirs=["/extra/include"])
+    reporter = MockProgressReporter()
+    function = MagicMock()
+    expected = object()
+    function.remote.aio = AsyncMock(return_value=expected)
+    config = {"lang": "cu"}
+
+    with patch("libkernelbot.launchers.modal.modal.Function.from_name", return_value=function):
+        result = await launcher.run_submission(config, get_gpu_by_name("B200"), reporter)
+
+    assert result is expected
+    assert config["include_dirs"] == ["/extra/include"]
+    function.remote.aio.assert_awaited_once_with(config=config)
+    function.remote.assert_not_called()
+    assert reporter.messages == ["⏳ Waiting for Modal run to finish..."]
+    assert reporter.updates == ["✅ Waiting for modal run to finish... Done"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- invoke deployed Modal functions with the native asynchronous `remote.aio()` API
- avoid routing long-lived Modal calls through Python's CPU-sized default thread pool
- add a focused regression test covering the async call, CUDA include configuration, returned result, and progress messages

## Why

`ModalLauncher.run_submission()` currently wraps blocking `Function.remote()` in `loop.run_in_executor(None, ...)`. Python sizes that shared default executor from the KernelBot host's CPU count, so the API host can silently cap Modal concurrency far below `BackgroundSubmissionManager.max_workers` and the Modal workspace GPU quota.

For example, an API container exposing three CPUs receives a seven-thread default executor. Even with 24 submission workers and a 50-GPU Modal allowance, only seven blocking calls can reach Modal at once; the rest wait locally in the executor.

Modal provides `remote.aio()` specifically for asynchronous callers, so this change removes that accidental CPU-derived bottleneck.

## Benefits

- lets KernelBot's existing 24-worker policy govern submission concurrency instead of API-host CPU count
- allows up to 24 ordinary Modal calls or 48 public/secret ranked calls to be in flight
- uses the Modal SDK's native non-blocking interface and avoids holding one local thread per remote GPU evaluation
- reduces hidden local queueing and makes Modal's backlog and GPU capacity the visible limiting layers
- preserves the existing remote function, configuration, return value, exception propagation, and progress reporting behavior

## Validation

- `uv run pytest tests/test_modal.py -m 'not integration' -q` — 3 passed, 11 deselected
- `uv run ruff check src/libkernelbot/launchers/modal.py tests/test_modal.py` — passed
- local GPU Mode experiment using `remote.aio()` — 12 ranked submissions produced 24 T4 calls, all completed, with 20 peak remote containers
- broader backend + Modal unit invocation reached 7 passing tests; 3 database-backed tests could not start because the local Docker daemon was unavailable
