### PR TITLE
Make trashtalk copy spartan

### DIFF
--- a/src/kernelbot/top_three.py
+++ b/src/kernelbot/top_three.py
@@ -1,48 +1,6 @@
-import random
 from dataclasses import dataclass
-from typing import Callable, Sequence, TypeVar
 
 from libkernelbot.db_types import LeaderboardRankedEntry
-
-T = TypeVar("T")
-Chooser = Callable[[Sequence[T]], T]
-
-WINNER_LINES = (
-    "Beautiful kernel. Absolutely no notes.",
-    "Someone check the profiler; that run left scorch marks.",
-    "The leaderboard has been optimized against its will.",
-    "That kernel did not ask permission before going fast.",
-    "Fresh crown, fewer nanoseconds. You love to see it.",
-    "The compiler watched this happen and felt something.",
-)
-
-ENTRANT_LINES = (
-    "The podium has a new problem.",
-    "Three chairs, one newly occupied. Things are getting spicy.",
-    "A wild contender has entered the profiler trace.",
-    "The top three just got a little less comfortable.",
-    "Turns out the velvet rope was only a suggestion.",
-)
-
-EVICTION_LINES = (
-    "gpumode.com will remember the good times.",
-    "Please collect your registers on the way out.",
-    "The podium has reclaimed your chair for higher utilization.",
-    "Your top-three residency has been garbage-collected.",
-    "You have been preempted. No checkpoint was saved.",
-    "The leaderboard called: your free trial has expired.",
-    "Back to the profiler mines. The nanoseconds demand tribute.",
-    "Your kernel is now a historical benchmark. Very educational.",
-)
-
-DETHRONED_LINES = (
-    "The crown is in another CUDA stream now.",
-    "First place was apparently a temporary allocation.",
-    "The throne had an eviction policy. Awkward.",
-    "You are now the reference implementation for getting passed.",
-    "The leaderboard diff says `-1 crown`. Brutal.",
-    "Your reign had excellent throughput and terrible retention.",
-)
 
 
 @dataclass(frozen=True)
@@ -89,37 +47,22 @@ def display_name(entry: LeaderboardRankedEntry) -> str:
     return f"**{entry['user_name']}**"
 
 
-def format_podium_change(
-    change: PodiumChange,
-    choose: Chooser[str] = random.choice,
-) -> str:
-    context = f"`{change.leaderboard_name}` on `{change.gpu_type}`"
+def format_podium_change(change: PodiumChange) -> str:
+    context = f"`{change.leaderboard_name}` (`{change.gpu_type}`)"
     lines: list[str] = []
 
     if change.winner is not None:
-        lines.append(
-            f"🏆 {display_name(change.winner)} just took **#1** on {context}. "
-            f"{choose(WINNER_LINES)}"
-        )
+        lines.append(f"{display_name(change.winner)} took **#1** on {context}.")
     else:
         for entrant in change.entrants:
-            lines.append(
-                f"🔥 {display_name(entrant)} just broke into the **top 3** on {context}. "
-                f"{choose(ENTRANT_LINES)}"
-            )
+            lines.append(f"{display_name(entrant)} entered the **top 3** on {context}.")
 
-    roasted_ids: set[str] = set()
+    departed_ids: set[str] = set()
     for departure in change.departures:
-        roasted_ids.add(str(departure["user_id"]))
-        lines.append(
-            f"🗑️ {display_name(departure)} has been evicted from the top 3. "
-            f"{choose(EVICTION_LINES)}"
-        )
+        departed_ids.add(str(departure["user_id"]))
+        lines.append(f"{display_name(departure)} fell out of the **top 3**.")
 
-    if change.dethroned is not None and str(change.dethroned["user_id"]) not in roasted_ids:
-        lines.append(
-            f"👑➡️🥈 {display_name(change.dethroned)} has been dethroned. "
-            f"{choose(DETHRONED_LINES)}"
-        )
+    if change.dethroned is not None and str(change.dethroned["user_id"]) not in departed_ids:
+        lines.append(f"{display_name(change.dethroned)} lost **#1**.")
 
     return "\n".join(lines)

--- a/tests/test_top_three.py
+++ b/tests/test_top_three.py
@@ -5,12 +5,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from kernelbot.cogs.top_three_cog import BEGINNER_LEADERBOARDS, TopThreeCog
-from kernelbot.top_three import (
-    EVICTION_LINES,
-    detect_podium_change,
-    display_name,
-    format_podium_change,
-)
+from kernelbot.top_three import detect_podium_change, display_name, format_podium_change
 
 
 def entry(user_id, name, rank):
@@ -27,22 +22,20 @@ def entry(user_id, name, rank):
     }
 
 
-def first(options):
-    return options[0]
-
-
 def test_new_winner_and_departure_are_both_called_out():
     before = [entry("1", "old-winner", 1), entry("2", "second", 2), entry("3", "third", 3)]
     after = [entry("4", "new-winner", 1), entry("1", "old-winner", 2), entry("2", "second", 3)]
 
     change = detect_podium_change("vector-add", "H100", before, after)
-    message = format_podium_change(change, choose=first)
+    message = format_podium_change(change)
 
     assert change.winner["user_id"] == "4"
     assert [item["user_id"] for item in change.departures] == ["3"]
-    assert "**new-winner** just took **#1**" in message
-    assert "**third** has been evicted" in message
-    assert "**old-winner** has been dethroned" in message
+    assert message == (
+        "**new-winner** took **#1** on `vector-add` (`H100`).\n"
+        "**third** fell out of the **top 3**.\n"
+        "**old-winner** lost **#1**."
+    )
 
 
 def test_new_third_place_without_winner_change():
@@ -50,11 +43,13 @@ def test_new_third_place_without_winner_change():
     after = [entry("1", "first", 1), entry("2", "second", 2), entry("4", "entrant", 3)]
 
     change = detect_podium_change("vector-add", "H100", before, after)
-    message = format_podium_change(change, choose=first)
+    message = format_podium_change(change)
 
     assert change.winner is None
-    assert "**entrant** just broke into the **top 3**" in message
-    assert "**third** has been evicted" in message
+    assert message == (
+        "**entrant** entered the **top 3** on `vector-add` (`H100`).\n"
+        "**third** fell out of the **top 3**."
+    )
 
 
 def test_personal_best_with_same_podium_is_silent():
@@ -71,20 +66,15 @@ def test_filling_first_three_slots_never_trashtalks(existing_count):
     newcomer = entry(str(existing_count + 1), f"user-{existing_count + 1}", existing_count + 1)
 
     change = detect_podium_change("vector-add", "H100", before, [*before, newcomer])
-    message = format_podium_change(change, choose=first)
+    message = format_podium_change(change)
 
     assert change.departures == ()
-    assert "evicted" not in message
-    assert "dethroned" not in message
+    assert "fell out" not in message
+    assert "lost **#1**" not in message
 
 
 def test_display_name_uses_public_leaderboard_username_without_ping():
     assert display_name(entry("12345", "octocat", 1)) == "**octocat**"
-
-
-def test_trashtalk_has_variety():
-    assert len(EVICTION_LINES) >= 8
-    assert len(set(EVICTION_LINES)) == len(EVICTION_LINES)
 
 
 def test_watcher_does_not_read_beginner_leaderboard_standings():
@@ -138,8 +128,8 @@ async def test_watcher_sends_api_visible_database_change_to_submissions_channel(
     await watcher.poll_once()
 
     channel.send.assert_awaited_once()
-    assert "**new-first** just took **#1**" in channel.send.await_args.args[0]
-    assert "**third** has been evicted" in channel.send.await_args.args[0]
+    assert "**new-first** took **#1**" in channel.send.await_args.args[0]
+    assert "**third** fell out of the **top 3**" in channel.send.await_args.args[0]
     assert watcher._standings[("vector-add", "H100")] == after
 
 
@@ -189,8 +179,8 @@ async def test_end_to_end_seed_api_update_and_discord_send():
 
     channel.send.assert_awaited_once()
     message = channel.send.await_args.args[0]
-    assert "**speed-demon** just took **#1**" in message
-    assert "**third** has been evicted" in message
+    assert "**speed-demon** took **#1**" in message
+    assert "**third** fell out of the **top 3**" in message
     assert "<@" not in message
 
 


### PR DESCRIPTION
## What changed

- replace randomized GPU memes with terse podium updates
- remove emoji and the random copy pools
- lock the exact announcement wording in tests

## Why

The meme-heavy messages were not landing. The bot now reports podium movement with short, dry competitive copy while preserving the existing watcher behavior.

## Validation

- `PYTHONPATH=src pytest -q tests/test_top_three.py` (11 passed)
- `ruff check src/kernelbot/top_three.py tests/test_top_three.py`
- `ruff format --check src/kernelbot/top_three.py tests/test_top_three.py`
