### PR TITLE
Clarify MathDx usage with load_inline

### DIFF
--- a/src/runners/modal_runner.py
+++ b/src/runners/modal_runner.py
@@ -33,10 +33,11 @@ mathdx_sha256 = "042b7c57a636c271cca32dffcc0a822ed6b2abc0b8ef5703ab2445d58563a1e
 #        cd src/runners && modal run test_cutlass_image.py
 #
 # For users writing submissions with torch.utils.cpp_extension.load_inline:
-#   C++ headers installed on the image (like CUTLASS) require explicit include paths:
+#   MathDx is already on CPLUS_INCLUDE_PATH. Include cuBLASDx in cuda_sources,
+#   which load_inline compiles with nvcc, rather than in cpp_sources:
 #     load_inline(
 #         ...
-#         extra_include_paths=["/opt/cutlass/include", "/opt/cutlass/tools/util/include"],
+#         cuda_sources=cuda_source,  # #include <cublasdx.hpp> goes here
 #     )
 #   For raw nvcc compilation, CPLUS_INCLUDE_PATH is set so includes work automatically.
 #


### PR DESCRIPTION
## Summary

Clarify the existing Modal runner guidance: MathDx headers are already installed and exported through `CPLUS_INCLUDE_PATH`, so `load_inline` users only need to put `#include <cublasdx.hpp>` in `cuda_sources` rather than `cpp_sources`.

## Why

`load_inline` compiles `cpp_sources` with the host C++ compiler and `cuda_sources` with NVCC. cuBLASDx belongs in the CUDA compilation unit; no additional Kernelbot image setting or submission compile flag is required.

## Impact

Comment-only change in `modal_runner.py`. No dependency, image, example, or test changes, and no Modal image was deployed.

## Validation

- `uv run --extra dev ruff check src/runners/modal_runner.py`
- `git diff --check`